### PR TITLE
Updates for S22 and fixes login error

### DIFF
--- a/SketchfabPlugin.pyp
+++ b/SketchfabPlugin.pyp
@@ -35,6 +35,7 @@ if not SKFB_DEPENDENCIES_PATH in sys.path:
     sys.path.insert(0, SKFB_DEPENDENCIES_PATH)
 
 from sketchfab.config import Config
+from sketchfab.utils import Utils
 from sketchfab.ui_importer import *
 from sketchfab.ui_exporter import *
 
@@ -103,6 +104,9 @@ if __name__ == "__main__":
     icon = bitmaps.BaseBitmap()
     iconPath = os.path.join(os.path.split(__file__)[0], "res", "icon.png")
     icon.InitWith(iconPath)
+
+    # Create the necessary directories
+    Utils.setup_plugin()
 
     # Register the importer
     plugins.RegisterCommandPlugin(id=Config.IMPORTER_ID,

--- a/sketchfab/api.py
+++ b/sketchfab/api.py
@@ -494,9 +494,6 @@ class ThreadedSearch(C4DThread):
         if uid not in self.skfb_api.search_results['current']:
             return
 
-        if not os.path.exists(Config.SKETCHFAB_THUMB_DIR):
-            os.makedirs(Config.SKETCHFAB_THUMB_DIR)
-
         preview_path = Utils.build_thumbnail_path(uid)
 
         if os.path.exists(preview_path):

--- a/sketchfab/config.py
+++ b/sketchfab/config.py
@@ -40,7 +40,7 @@ class Config:
 
     # sometimes the path in preferences is empty
     def get_temp_path():
-        return c4d.storage.GeGetC4DPath(c4d.C4D_PATH_PREFS)
+        return c4d.storage.GeGetStartupWritePath()
 
     GITHUB_REPOSITORY_URL = 'https://github.com/sketchfab/c4d-plugin'
     PLUGIN_LATEST_RELEASE = GITHUB_REPOSITORY_URL + '/releases/latest'

--- a/sketchfab/config.py
+++ b/sketchfab/config.py
@@ -19,7 +19,7 @@ from c4d import storage
 
 class Config:
 
-    PLUGIN_VERSION = "1.3.0"
+    PLUGIN_VERSION = "1.3.1"
     PLUGIN_TITLE   = "Sketchfab Plugin"
     PLUGIN_AUTHOR  = "Sketchfab"
     PLUGIN_TWITTER = "@sketchfab"

--- a/sketchfab/ui_exporter.py
+++ b/sketchfab/ui_exporter.py
@@ -68,7 +68,6 @@ export_options = {
 	c4d.FBXEXPORT_SPLINES: 1,
 	# Geometry and Materials
 	c4d.FBXEXPORT_SAVE_NORMALS: 1,
-	c4d.FBXEXPORT_TEXTURES: 1,
 	c4d.FBXEXPORT_EMBED_TEXTURES: 1,
 	c4d.FBXEXPORT_FBX_VERSION: c4d.FBX_EXPORTVERSION_NATIVE,
 	# cancel all these one
@@ -78,6 +77,15 @@ export_options = {
 	c4d.FBXEXPORT_SDS_SUBDIVISION: 1,
 	c4d.FBXEXPORT_ASCII: 0
 }
+
+# Take API changes from R22 into account
+# https://developers.maxon.net/docs/Cinema4DPythonSDK/html/misc/changelog/changelog_s22.html
+if c4d.GetC4DVersion() >= 22000:
+	export_options[c4d.FBXEXPORT_BAKE_MATERIALS] = 0
+	export_options[c4d.FBXEXPORT_MATERIALS] = c4d.FBXEXPORT_MATERIALS_PHONGLAMBERT
+else:
+	# In S22+, this becomes enforced by FBXEXPORT_EMBED_TEXTURES
+	export_options[c4d.FBXEXPORT_TEXTURES] = 1
 
 # Globals
 g_uploaded = False

--- a/sketchfab/ui_importer.py
+++ b/sketchfab/ui_importer.py
@@ -499,6 +499,8 @@ class SkfbModelDialog(gui.GeDialog):
 
 		if not caption:
 			caption = "IMPORT MODEL" if self.skfb_api.is_user_logged() else "You need to be logged in"
+		if self.skfb_model is not None and self.skfb_model.download_size:
+			caption += " (" + self.skfb_model.download_size + ")"
 
 		self.AddButton(id=BTN_IMPORT, flags=c4d.BFH_CENTER | c4d.BFV_CENTER, initw=200, inith=38, name=caption)
 		self.LayoutChanged(GROUP_MODEL_IMPORT)

--- a/sketchfab/utils.py
+++ b/sketchfab/utils.py
@@ -104,6 +104,8 @@ class Utils:
             os.makedirs(Config.SKETCHFAB_TEMP_DIR)
         if not os.path.exists(Config.SKETCHFAB_THUMB_DIR):
             os.makedirs(Config.SKETCHFAB_THUMB_DIR)
+        if not os.path.exists(Config.SKETCHFAB_MODEL_DIR):
+            os.makedirs(Config.SKETCHFAB_MODEL_DIR)
     @staticmethod
     def get_uid_from_thumbnail_url(thumbnail_url):
         return thumbnail_url.split('/')[4]


### PR DESCRIPTION
Some API changes in R22 have to be taken into account for the plugin to be compatible with the FBX export.

Also, updates the login by storing the cache file in a user directory, avoiding permission errors.